### PR TITLE
Add test for trailing bound

### DIFF
--- a/spec/anchors_spec.rb
+++ b/spec/anchors_spec.rb
@@ -106,4 +106,8 @@ describe "matching_the_word_and" do
   it "does not match 'demand'" do
     expect(Anchors.new.matching_the_word_and).not_to match "i demand to see the papers"
   end
+  
+  it "does not match 'andrew'" do
+    expect(Anchors.new.matching_the_word_and).not_to match "i saw a merry andrew"
+  end
 end


### PR DESCRIPTION
Without this test a regex like this `/\band/` will pass the tests but it shouldn't.